### PR TITLE
RN 0.39 Backwards Compatible Imports

### DIFF
--- a/ios/RNGoogleSignIn/RNGoogleSignIn-Bridging-Header.h
+++ b/ios/RNGoogleSignIn/RNGoogleSignIn-Bridging-Header.h
@@ -2,7 +2,7 @@
 #define RNGoogleSignIn_Bridging_Header_h
 
 #if __has_include(<React/RCTBridgeModule.h>)
-  #import <React/RCTBridgeModule.hh>
+  #import <React/RCTBridgeModule.h>
 #elif __has_include("RCTBridgeModule.h")
   #import "RCTBridgeModule.h"
 #else
@@ -10,7 +10,7 @@
 #endif
 
 #if __has_include(<React/RCTViewManager.h>)
-  #import <React/RCTViewManager.hh>
+  #import <React/RCTViewManager.h>
 #elif __has_include("RCTViewManager.h")
   #import "RCTViewManager.h"
 #else
@@ -18,7 +18,7 @@
 #endif
 
 #if __has_include(<React/RCTEventEmitter.h>)
-  #import <React/RCTEventEmitter.hh>
+  #import <React/RCTEventEmitter.h>
 #elif __has_include("RCTEventEmitter.h")
   #import "RCTEventEmitter.h"
 #else

--- a/ios/RNGoogleSignIn/RNGoogleSignIn-Bridging-Header.h
+++ b/ios/RNGoogleSignIn/RNGoogleSignIn-Bridging-Header.h
@@ -1,9 +1,30 @@
 #ifndef RNGoogleSignIn_Bridging_Header_h
 #define RNGoogleSignIn_Bridging_Header_h
 
-#import <React/RCTBridgeModule.h>
-#import <React/RCTViewManager.h>
-#import <React/RCTEventEmitter.h>
+#if __has_include(<React/RCTBridgeModule.h>)
+  #import <React/RCTBridgeModule.hh>
+#elif __has_include("RCTBridgeModule.h")
+  #import "RCTBridgeModule.h"
+#else
+  #import "React/RCTBridgeModule.h"
+#endif
+
+#if __has_include(<React/RCTViewManager.h>)
+  #import <React/RCTViewManager.hh>
+#elif __has_include("RCTViewManager.h")
+  #import "RCTViewManager.h"
+#else
+  #import "React/RCTViewManager.h"
+#endif
+
+#if __has_include(<React/RCTEventEmitter.h>)
+  #import <React/RCTEventEmitter.hh>
+#elif __has_include("RCTEventEmitter.h")
+  #import "RCTEventEmitter.h"
+#else
+  #import "React/RCTEventEmitter.h"
+#endif
+
 #import <Google/SignIn.h>
 
 #endif /* RNGoogleSignIn_Bridging_Header_h */

--- a/ios/RNGoogleSignIn/RNGoogleSignInBridge.m
+++ b/ios/RNGoogleSignIn/RNGoogleSignInBridge.m
@@ -7,7 +7,13 @@
 
 #import <Foundation/Foundation.h>
 
-#import <React/RCTBridgeModule.h>
+#if __has_include(<React/RCTBridgeModule.h>)
+  #import <React/RCTBridgeModule.hh>
+#elif __has_include("RCTBridgeModule.h")
+  #import "RCTBridgeModule.h"
+#else
+  #import "React/RCTBridgeModule.h"
+#endif
 
 @interface RCT_EXTERN_MODULE(RNGoogleSignIn, NSObject)
 

--- a/ios/RNGoogleSignIn/RNGoogleSignInBridge.m
+++ b/ios/RNGoogleSignIn/RNGoogleSignInBridge.m
@@ -8,7 +8,7 @@
 #import <Foundation/Foundation.h>
 
 #if __has_include(<React/RCTBridgeModule.h>)
-  #import <React/RCTBridgeModule.hh>
+  #import <React/RCTBridgeModule.h>
 #elif __has_include("RCTBridgeModule.h")
   #import "RCTBridgeModule.h"
 #else

--- a/ios/RNGoogleSignIn/RNGoogleSignInEventsBridge.m
+++ b/ios/RNGoogleSignIn/RNGoogleSignInEventsBridge.m
@@ -8,7 +8,7 @@
 #import <Foundation/Foundation.h>
 
 #if __has_include(<React/RCTBridgeModule.h>)
-  #import <React/RCTBridgeModule.hh>
+  #import <React/RCTBridgeModule.h>
 #elif __has_include("RCTBridgeModule.h")
   #import "RCTBridgeModule.h"
 #else

--- a/ios/RNGoogleSignIn/RNGoogleSignInEventsBridge.m
+++ b/ios/RNGoogleSignIn/RNGoogleSignInEventsBridge.m
@@ -7,7 +7,13 @@
 
 #import <Foundation/Foundation.h>
 
-#import <React/RCTBridgeModule.h>
+#if __has_include(<React/RCTBridgeModule.h>)
+  #import <React/RCTBridgeModule.hh>
+#elif __has_include("RCTBridgeModule.h")
+  #import "RCTBridgeModule.h"
+#else
+  #import "React/RCTBridgeModule.h"
+#endif
 
 @interface RCT_EXTERN_MODULE(RNGoogleSignInEvents, NSObject)
 


### PR DESCRIPTION
App that I'm working is using RN version < 0.40 so it's incompatible to use the imports from namespace 'React'. This workaround to stay compatible with all RN versions works good for me.