### PR TITLE
Add signInSilentlyPromise for refreshing accessToken

### DIFF
--- a/js/GoogleSignIn.android.js
+++ b/js/GoogleSignIn.android.js
@@ -111,6 +111,24 @@ const GoogleSignIn = {
     RNGoogleSignIn.signInSilently();
   },
 
+  // Sign in without a prompt
+  // If accessToken is expiring, refresh it
+  signInSilentlyPromise() {
+    return new Promise((resolve, reject) => {
+      const offSuccess = GoogleSignIn.onSignIn((data) => {
+        offSuccess();
+        offError();
+        resolve(GoogleSignIn.normalizeUser(data));
+      });
+      const offError = GoogleSignIn.onSignInError((error) => {
+        offSuccess();
+        offError();
+        reject(error);
+      });
+      RNGoogleSignIn.signInSilently();
+    });
+  },
+
   disconnect() {
     RNGoogleSignIn.disconnect();
   },

--- a/js/GoogleSignIn.ios.js
+++ b/js/GoogleSignIn.ios.js
@@ -118,6 +118,24 @@ const GoogleSignIn = {
     RNGoogleSignIn.signInSilently();
   },
 
+  // Sign in without a prompt
+  // If accessToken is expiring, refresh it
+  signInSilentlyPromise() {
+    return new Promise((resolve, reject) => {
+      const offSuccess = GoogleSignIn.onSignIn((data) => {
+        offSuccess();
+        offError();
+        resolve(GoogleSignIn.normalizeUser(data));
+      });
+      const offError = GoogleSignIn.onSignInError((error) => {
+        offSuccess();
+        offError();
+        reject(error);
+      });
+      RNGoogleSignIn.signInSilently();
+    });
+  },
+
   disconnect() {
     RNGoogleSignIn.disconnect();
   },


### PR DESCRIPTION
This pull request add promise-returning-method for signing in silently.

Calling signInSilently will return user with valid accessToken even if it was previously expired.

Thanks for great library! Previously I was stuck with the outdated [devfd](https://github.com/devfd/react-native-google-signin) one...