### PR TITLE
use the top-most ViewController

### DIFF
--- a/ios/RNGoogleSignIn/RNGoogleSignIn.swift
+++ b/ios/RNGoogleSignIn/RNGoogleSignIn.swift
@@ -107,7 +107,16 @@ class RNGoogleSignIn: NSObject, GIDSignInUIDelegate {
   }
   
   func sign(_ signIn: GIDSignIn!, present viewController: UIViewController!) {
-    UIApplication.shared.keyWindow?.rootViewController?.present(viewController, animated: true, completion: nil)
+    let parent = self.topMostViewController()
+    parent?.present(viewController, animated:true, completion:nil)
+  }
+    
+  func topMostViewController() -> UIViewController? {
+    var topController = UIApplication.shared.keyWindow?.rootViewController
+    while topController?.presentedViewController != nil {
+      topController = topController?.presentedViewController
+    }
+    return topController
   }
   
   // END: GIDSignInUIDelegate


### PR DESCRIPTION
iOS: use the top-most ViewController to present SFSafariViewController instead of using rootViewController. This makes Google login work inside react-native-navigation modals.