### PR TITLE
updated import bug for bridging header

### DIFF
--- a/ios/RNGoogleSignIn/RNGoogleSignIn-Bridging-Header.h
+++ b/ios/RNGoogleSignIn/RNGoogleSignIn-Bridging-Header.h
@@ -25,6 +25,6 @@
   #import "React/RCTEventEmitter.h"
 #endif
 
-#import <Google/SignIn.h>
+#import <GoogleSignIn/GoogleSignIn.h>
 
 #endif /* RNGoogleSignIn_Bridging_Header_h */


### PR DESCRIPTION
```
error: 'Google/SignIn.h' file not found
#import <Google/SignIn.h>
```